### PR TITLE
Accesibilidad: aria-hidden en menú móvil + ARIA tabs en comparador

### DIFF
--- a/critical-fixes.patch
+++ b/critical-fixes.patch
@@ -1,0 +1,87 @@
+*** Begin Patch
+*** Update File: js/header.js
+@@
+   if (e.key !== 'Tab') return;
+ 
+   const nodes = mobileMenu.querySelectorAll(focusableSel);
+   const first = nodes[0];
+   const last = nodes[nodes.length - 1];
+@@
+     }
+   }
++
++  // Oculta / restaura el contenido de fondo a las tecnologías de asistencia
++  // (cuando el diálogo del menú móvil está abierto)
++  function setBackgroundHidden(hidden) {
++    try {
++      document.querySelectorAll('main, footer, .site-footer').forEach(function (el) {
++        if (!el) return;
++        if (hidden) el.setAttribute('aria-hidden', 'true');
++        else el.removeAttribute('aria-hidden');
++      });
++    } catch (err) { /* no-op */ }
++  }
+@@
+   function openMenu() {
+@@
+     // Bloquea el scroll de la página de fondo
+     document.body.style.overflow = 'hidden';
++
++    // Oculta el fondo a AT (mejora compatibilidad de aria-modal)
++    setBackgroundHidden(true);
+@@
+   function closeMenu() {
++    // Restaura visibilidad del fondo a AT
++    setBackgroundHidden(false);
+     // Quita la clase visual del menú
+     mobileMenu.classList.remove('is-open');
+*** End Patch
+
+*** Begin Patch
+*** Update File: pages/arroz-con-pollo-scraped.html
+@@
+-                <nav class="ingredient-tabs" aria-label="Ingredientes">
+-                    <button class="ingredient-tabs__item is-active" type="button" data-ingredient="habichuela">Habichuela</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="arroz">Arroz</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="pimenton">Pimentón</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="cebolla">Cebolla</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="pechuga">Pechuga</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="arveja">Arveja</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="condimento">Condimento</button>
+-                    <button class="ingredient-tabs__item" type="button" data-ingredient="ajo">Ajo</button>
+-                </nav>
++                <nav class="ingredient-tabs" role="tablist" aria-label="Ingredientes">
++                    <button id="tab-habichuela" class="ingredient-tabs__item is-active" type="button" data-ingredient="habichuela" role="tab" aria-selected="true" aria-controls="panel-habichuela">Habichuela</button>
++                    <button id="tab-arroz" class="ingredient-tabs__item" type="button" data-ingredient="arroz" role="tab" aria-selected="false" aria-controls="panel-arroz" tabindex="-1">Arroz</button>
++                    <button id="tab-pimenton" class="ingredient-tabs__item" type="button" data-ingredient="pimenton" role="tab" aria-selected="false" aria-controls="panel-pimenton" tabindex="-1">Pimentón</button>
++                    <button id="tab-cebolla" class="ingredient-tabs__item" type="button" data-ingredient="cebolla" role="tab" aria-selected="false" aria-controls="panel-cebolla" tabindex="-1">Cebolla</button>
++                    <button id="tab-pechuga" class="ingredient-tabs__item" type="button" data-ingredient="pechuga" role="tab" aria-selected="false" aria-controls="panel-pechuga" tabindex="-1">Pechuga</button>
++                    <button id="tab-arveja" class="ingredient-tabs__item" type="button" data-ingredient="arveja" role="tab" aria-selected="false" aria-controls="panel-arveja" tabindex="-1">Arveja</button>
++                    <button id="tab-condimento" class="ingredient-tabs__item" type="button" data-ingredient="condimento" role="tab" aria-selected="false" aria-controls="panel-condimento" tabindex="-1">Condimento</button>
++                    <button id="tab-ajo" class="ingredient-tabs__item" type="button" data-ingredient="ajo" role="tab" aria-selected="false" aria-controls="panel-ajo" tabindex="-1">Ajo</button>
++                </nav>
+@@
+-                <section class="market-grid is-active" data-ingredient="habichuela" aria-label="Habichuela - Comparación de supermercados">
++                <section id="panel-habichuela" class="market-grid is-active" data-ingredient="habichuela" aria-label="Habichuela - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-habichuela" tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="arroz" aria-label="Arroz - Comparación de supermercados" hidden>
++                <section id="panel-arroz" class="market-grid" data-ingredient="arroz" aria-label="Arroz - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-arroz" hidden tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="pimenton" aria-label="Pimentón - Comparación de supermercados" hidden>
++                <section id="panel-pimenton" class="market-grid" data-ingredient="pimenton" aria-label="Pimentón - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-pimenton" hidden tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="cebolla" aria-label="Cebolla - Comparación de supermercados" hidden>
++                <section id="panel-cebolla" class="market-grid" data-ingredient="cebolla" aria-label="Cebolla - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-cebolla" hidden tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="pechuga" aria-label="Pechuga - Comparación de supermercados" hidden>
++                <section id="panel-pechuga" class="market-grid" data-ingredient="pechuga" aria-label="Pechuga - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-pechuga" hidden tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="arveja" aria-label="Arveja - Comparación de supermercados" hidden>
++                <section id="panel-arveja" class="market-grid" data-ingredient="arveja" aria-label="Arveja - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-arveja" hidden tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="condimento" aria-label="Condimento - Comparación de supermercados" hidden>
++                <section id="panel-condimento" class="market-grid" data-ingredient="condimento" aria-label="Condimento - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-condimento" hidden tabindex="0">
+@@
+-                <section class="market-grid" data-ingredient="ajo" aria-label="Ajo - Comparación de supermercados" hidden>
++                <section id="panel-ajo" class="market-grid" data-ingredient="ajo" aria-label="Ajo - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-ajo" hidden tabindex="0">
+*** End Patch

--- a/index.html
+++ b/index.html
@@ -70,7 +70,8 @@
                     aria-label="Abrir menú"
                 >
                     <img
-                        src = "assets/icons/Menu.svg"
+                        src="assets/icons/Menu.svg"
+                        alt=""
                         aria-hidden="true"
                         focusable="false"
                     >

--- a/js/header.js
+++ b/js/header.js
@@ -45,6 +45,18 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  // Oculta / restaura el contenido de fondo a las tecnologías de asistencia
+  // (cuando el diálogo del menú móvil está abierto)
+  function setBackgroundHidden(hidden) {
+    try {
+      document.querySelectorAll('main, footer, .site-footer').forEach(function (el) {
+        if (!el) return;
+        if (hidden) el.setAttribute('aria-hidden', 'true');
+        else el.removeAttribute('aria-hidden');
+      });
+    } catch (err) { /* no-op */ }
+  }
+
   // Abre el menú móvil, bloquea el scroll del fondo y mueve el foco al primer control
   // Abre el menú móvil
   function openMenu() {
@@ -70,6 +82,9 @@ document.addEventListener('DOMContentLoaded', function () {
     // Bloquea el scroll de la página de fondo
     document.body.style.overflow = 'hidden';
 
+    // Oculta el fondo a AT (mejora compatibilidad de aria-modal)
+    setBackgroundHidden(true);
+
     // Busca el primer elemento interactivo dentro del menú
     // (link, botón, etc.)
     const f = mobileMenu.querySelector(focusableSel);
@@ -85,6 +100,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Cierra el menú móvil, restaura el estado inicial y devuelve el foco
   function closeMenu() {
+    // Restaura visibilidad del fondo a AT
+    setBackgroundHidden(false);
     // Quita la clase visual del menú
     mobileMenu.classList.remove('is-open');
 

--- a/pages/arroz-con-pollo-info.html
+++ b/pages/arroz-con-pollo-info.html
@@ -44,7 +44,7 @@
                 </a>
 
                 <button class="menu-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
-                    <img src="../assets/icons/Menu.svg" aria-hidden="true" focusable="false">
+                    <img src="../assets/icons/Menu.svg" alt="" aria-hidden="true" focusable="false">
                 </button>
             </div>
         </div>

--- a/pages/arroz-con-pollo-scraped.html
+++ b/pages/arroz-con-pollo-scraped.html
@@ -27,7 +27,7 @@
     <!-- Script para cambiar entre ingredientes -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            const tabs = document.querySelectorAll('.ingredient-tabs__item');
+            const tabs = Array.from(document.querySelectorAll('.ingredient-tabs__item'));
             const compareButton = document.getElementById('compare-ingredients-btn');
             const ingredientSection = document.getElementById('ingredient-section');
             const scrapingInfo = document.getElementById('scraping-info');
@@ -80,55 +80,93 @@
                     }
                 });
             }
-            
-            tabs.forEach(tab => {
-                tab.addEventListener('click', function() {
-                    const ingredientName = this.dataset.ingredient;
-                    
-                    // Remove active state from all tabs
-                    tabs.forEach(t => t.classList.remove('is-active'));
-                    
-                    // Add active state to clicked tab
-                    this.classList.add('is-active');
-                    
-                    // Hide all market grids
-                    const grids = document.querySelectorAll('.market-grid');
-                    grids.forEach(grid => {
-                        grid.hidden = true;
-                        grid.classList.remove('is-active');
-                    });
-                    
-                    // Show the selected grid
-                    const selectedGrid = document.querySelector(`.market-grid[data-ingredient="${ingredientName}"]`);
-                    if (selectedGrid) {
-                        selectedGrid.hidden = false;
-                        selectedGrid.classList.add('is-active');
+
+            function activateTab(tab, setFocusToPanel = true) {
+                if (!tab) return;
+                tabs.forEach(function(t) {
+                    const selected = t === tab;
+                    t.classList.toggle('is-active', selected);
+                    t.setAttribute('aria-selected', selected ? 'true' : 'false');
+                    t.tabIndex = selected ? 0 : -1;
+                });
+
+                const ingredientName = tab.dataset.ingredient;
+                const grids = document.querySelectorAll('.market-grid');
+                grids.forEach(function(grid) {
+                    const match = grid.dataset.ingredient === ingredientName;
+                    grid.hidden = !match;
+                    grid.classList.toggle('is-active', match);
+                    if (match && setFocusToPanel) {
+                        try { grid.focus(); } catch (e) { /* ignore */ }
                     }
                 });
+            }
+
+            function focusTabAt(index) {
+                if (!tabs.length) return;
+                const i = (index + tabs.length) % tabs.length;
+                tabs[i].focus();
+            }
+
+            function onTabKeydown(e) {
+                const el = e.currentTarget;
+                const idx = tabs.indexOf(el);
+
+                switch (e.key) {
+                    case 'ArrowLeft':
+                    case 'ArrowUp':
+                        e.preventDefault();
+                        focusTabAt(idx - 1);
+                        break;
+                    case 'ArrowRight':
+                    case 'ArrowDown':
+                        e.preventDefault();
+                        focusTabAt(idx + 1);
+                        break;
+                    case 'Home':
+                        e.preventDefault();
+                        focusTabAt(0);
+                        break;
+                    case 'End':
+                        e.preventDefault();
+                        focusTabAt(tabs.length - 1);
+                        break;
+                    case 'Enter':
+                    case ' ':
+                        e.preventDefault();
+                        activateTab(el);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            tabs.forEach(function(tab) {
+                tab.addEventListener('click', function() { activateTab(tab); });
+                tab.addEventListener('keydown', onTabKeydown);
             });
+
+            // Ensure an initial selected tab exists and panels match
+            const initial = tabs.find(function(t) { return t.getAttribute('aria-selected') === 'true'; }) || tabs[0];
+            if (initial) activateTab(initial, false);
 
             if (compareButton && ingredientSection) {
                 compareButton.addEventListener('click', function () {
                     ingredientSection.hidden = false;
                     compareButton.setAttribute('aria-expanded', 'true');
-                    if (scrapingInfo) {
-                        scrapingInfo.hidden = false;
-                    }
+                    if (scrapingInfo) scrapingInfo.hidden = false;
                     localStorage.setItem(compareStateKey, 'true');
+                    // focus the active tab for keyboard users
+                    const active = tabs.find(function(t) { return t.getAttribute('aria-selected') === 'true'; }) || tabs[0];
                     ingredientSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    if (active) active.focus();
                 });
             }
 
             if (localStorage.getItem(compareStateKey) === 'true') {
-                if (ingredientSection) {
-                    ingredientSection.hidden = false;
-                }
-                if (scrapingInfo) {
-                    scrapingInfo.hidden = false;
-                }
-                if (compareButton) {
-                    compareButton.setAttribute('aria-expanded', 'true');
-                }
+                if (ingredientSection) ingredientSection.hidden = false;
+                if (scrapingInfo) scrapingInfo.hidden = false;
+                if (compareButton) compareButton.setAttribute('aria-expanded', 'true');
             } else if (compareButton) {
                 compareButton.setAttribute('aria-expanded', 'false');
             }

--- a/pages/arroz-con-pollo-scraped.html
+++ b/pages/arroz-con-pollo-scraped.html
@@ -187,6 +187,7 @@
                 >
                     <img
                         src="../assets/icons/Menu.svg"
+                        alt=""
                         aria-hidden="true"
                         focusable="false"
                     >

--- a/pages/arroz-con-pollo-scraped.html
+++ b/pages/arroz-con-pollo-scraped.html
@@ -33,6 +33,10 @@
             const scrapingInfo = document.getElementById('scraping-info');
             const compareStateKey = 'foodsaverRecipeCompareOpen';
 
+            function prefersReducedMotion() {
+                return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            }
+
             function parsePrice(text) {
                 const numeric = Number((text || '').replace(/[^0-9]/g, ''));
                 return Number.isFinite(numeric) ? numeric : Number.POSITIVE_INFINITY;
@@ -96,8 +100,16 @@
                     const match = grid.dataset.ingredient === ingredientName;
                     grid.hidden = !match;
                     grid.classList.toggle('is-active', match);
+                    try { grid.setAttribute('aria-hidden', (!match).toString()); } catch (e) {}
                     if (match && setFocusToPanel) {
-                        try { grid.focus(); } catch (e) { /* ignore */ }
+                        try {
+                            try { grid.focus({ preventScroll: true }); } catch (err) { if (grid.focus) grid.focus(); }
+                            if (!prefersReducedMotion()) {
+                                try { grid.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (e) { grid.scrollIntoView(true); }
+                            } else {
+                                try { grid.scrollIntoView({ behavior: 'auto', block: 'start' }); } catch (e) { grid.scrollIntoView(true); }
+                            }
+                        } catch (e) { /* ignore */ }
                     }
                 });
             }
@@ -156,10 +168,16 @@
                     compareButton.setAttribute('aria-expanded', 'true');
                     if (scrapingInfo) scrapingInfo.hidden = false;
                     localStorage.setItem(compareStateKey, 'true');
-                    // focus the active tab for keyboard users
+                    // focus the active tab for keyboard users without jump
                     const active = tabs.find(function(t) { return t.getAttribute('aria-selected') === 'true'; }) || tabs[0];
-                    ingredientSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    if (active) active.focus();
+                    if (active) {
+                        try { active.focus({ preventScroll: true }); } catch (e) { active.focus(); }
+                        if (!prefersReducedMotion()) {
+                            try { ingredientSection.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (e) { ingredientSection.scrollIntoView(true); }
+                        } else {
+                            try { ingredientSection.scrollIntoView({ behavior: 'auto', block: 'start' }); } catch (e) { ingredientSection.scrollIntoView(true); }
+                        }
+                    }
                 });
             }
 

--- a/pages/arroz-con-pollo-scraped.html
+++ b/pages/arroz-con-pollo-scraped.html
@@ -275,19 +275,19 @@
         <!-- Ingredientes -->
         <section class="recipe-detail__section container" aria-labelledby="recipe-title">
             <section id="ingredient-section" class="ingredient-section" aria-label="Comparador por ingrediente" hidden>
-                <nav class="ingredient-tabs" aria-label="Ingredientes">
-                    <button class="ingredient-tabs__item is-active" type="button" data-ingredient="habichuela">Habichuela</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="arroz">Arroz</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="pimenton">Pimentón</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="cebolla">Cebolla</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="pechuga">Pechuga</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="arveja">Arveja</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="condimento">Condimento</button>
-                    <button class="ingredient-tabs__item" type="button" data-ingredient="ajo">Ajo</button>
+                <nav class="ingredient-tabs" role="tablist" aria-label="Ingredientes">
+                    <button id="tab-habichuela" class="ingredient-tabs__item is-active" type="button" data-ingredient="habichuela" role="tab" aria-selected="true" aria-controls="panel-habichuela">Habichuela</button>
+                    <button id="tab-arroz" class="ingredient-tabs__item" type="button" data-ingredient="arroz" role="tab" aria-selected="false" aria-controls="panel-arroz" tabindex="-1">Arroz</button>
+                    <button id="tab-pimenton" class="ingredient-tabs__item" type="button" data-ingredient="pimenton" role="tab" aria-selected="false" aria-controls="panel-pimenton" tabindex="-1">Pimentón</button>
+                    <button id="tab-cebolla" class="ingredient-tabs__item" type="button" data-ingredient="cebolla" role="tab" aria-selected="false" aria-controls="panel-cebolla" tabindex="-1">Cebolla</button>
+                    <button id="tab-pechuga" class="ingredient-tabs__item" type="button" data-ingredient="pechuga" role="tab" aria-selected="false" aria-controls="panel-pechuga" tabindex="-1">Pechuga</button>
+                    <button id="tab-arveja" class="ingredient-tabs__item" type="button" data-ingredient="arveja" role="tab" aria-selected="false" aria-controls="panel-arveja" tabindex="-1">Arveja</button>
+                    <button id="tab-condimento" class="ingredient-tabs__item" type="button" data-ingredient="condimento" role="tab" aria-selected="false" aria-controls="panel-condimento" tabindex="-1">Condimento</button>
+                    <button id="tab-ajo" class="ingredient-tabs__item" type="button" data-ingredient="ajo" role="tab" aria-selected="false" aria-controls="panel-ajo" tabindex="-1">Ajo</button>
                 </nav>
 
                 <!-- Habichuela Section -->
-                <section class="market-grid is-active" data-ingredient="habichuela" aria-label="Habichuela - Comparación de supermercados">
+                <section id="panel-habichuela" class="market-grid is-active" data-ingredient="habichuela" aria-label="Habichuela - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-habichuela" tabindex="0">
                 <article class="market-card">
                     <img
                         src="../assets/images/ingredientes/Habichuela Ekono.jpg"
@@ -341,7 +341,7 @@
                 </section>
 
                 <!-- Arroz Section -->
-                <section class="market-grid" data-ingredient="arroz" aria-label="Arroz - Comparación de supermercados" hidden>
+                <section id="panel-arroz" class="market-grid" data-ingredient="arroz" aria-label="Arroz - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-arroz" hidden tabindex="0">
                 <article class="market-card">
                     <img
                         src="../assets/images/ingredientes/Arroz-Diana-1000-gr.jpg"
@@ -395,7 +395,7 @@
                 </section>
 
                 <!-- Pimentón Section -->
-                <section class="market-grid" data-ingredient="pimenton" aria-label="Pimentón - Comparación de supermercados" hidden>
+                <section id="panel-pimenton" class="market-grid" data-ingredient="pimenton" aria-label="Pimentón - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-pimenton" hidden tabindex="0">
                 <article class="market-card">
                     <img
                         src="../assets/images/ingredientes/Pimenton-Colores- Exito.jpg"
@@ -449,7 +449,7 @@
                 </section>
 
                 <!-- Cebolla Section -->
-                <section class="market-grid" data-ingredient="cebolla" aria-label="Cebolla - Comparación de supermercados" hidden>
+                <section id="panel-cebolla" class="market-grid" data-ingredient="cebolla" aria-label="Cebolla - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-cebolla" hidden tabindex="0">
                 <article class="market-card">
                     <img
                         src="../assets/images/ingredientes/CEBOLLA-BLANCA-UNIDAD EXITO.jpg"
@@ -503,7 +503,7 @@
                 </section>
 
                 <!-- Pechuga Section -->
-                <section class="market-grid" data-ingredient="pechuga" aria-label="Pechuga - Comparación de supermercados" hidden>
+                <section id="panel-pechuga" class="market-grid" data-ingredient="pechuga" aria-label="Pechuga - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-pechuga" hidden tabindex="0">
                     <article class="market-card">
                         <img
                             src="../assets/images/ingredientes/PECHUGA-SI-CAMPESINA-EXITO.jpg"
@@ -557,7 +557,7 @@
                 </section>
 
                 <!-- Arveja Section -->
-                <section class="market-grid" data-ingredient="arveja" aria-label="Arveja - Comparación de supermercados" hidden>
+                <section id="panel-arveja" class="market-grid" data-ingredient="arveja" aria-label="Arveja - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-arveja" hidden tabindex="0">
                     <article class="market-card">
                         <img
                             src="../assets/images/ingredientes/Arveja-Amarilla-Frescampo EXITO.jpg"
@@ -611,7 +611,7 @@
                 </section>
 
                 <!-- Condimento Section -->
-                <section class="market-grid" data-ingredient="condimento" aria-label="Condimento - Comparación de supermercados" hidden>
+                <section id="panel-condimento" class="market-grid" data-ingredient="condimento" aria-label="Condimento - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-condimento" hidden tabindex="0">
                     <article class="market-card">
                         <img
                             src="../assets/images/ingredientes/Tricompleto-El-Rey-X-Exito.jpg"
@@ -665,7 +665,7 @@
                 </section>
 
                 <!-- Ajo Section -->
-                <section class="market-grid" data-ingredient="ajo" aria-label="Ajo - Comparación de supermercados" hidden>
+                <section id="panel-ajo" class="market-grid" data-ingredient="ajo" aria-label="Ajo - Comparación de supermercados" role="tabpanel" aria-labelledby="tab-ajo" hidden tabindex="0">
                     <article class="market-card">
                         <img
                             src="../assets/images/ingredientes/Ajo-Importado-Malla-Paquete-Exito.jpg"

--- a/pages/aviso-legal.html
+++ b/pages/aviso-legal.html
@@ -44,7 +44,7 @@
                 </a>
 
                 <button class="menu-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
-                    <img src="../assets/icons/Menu.svg" aria-hidden="true" focusable="false">
+                    <img src="../assets/icons/Menu.svg" alt="" aria-hidden="true" focusable="false">
                 </button>
             </div>
         </div>

--- a/pages/carrito.html
+++ b/pages/carrito.html
@@ -73,7 +73,8 @@
                     aria-label="Abrir menú"
                 >
                     <img
-                        src = "../assets/icons/Menu.svg"
+                        src="../assets/icons/Menu.svg"
+                        alt=""
                         aria-hidden="true"
                         focusable="false"
                     >

--- a/pages/colombiana.html
+++ b/pages/colombiana.html
@@ -45,7 +45,7 @@
                 </a>
 
                 <button class="menu-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
-                    <img src="../assets/icons/Menu.svg" aria-hidden="true" focusable="false">
+                    <img src="../assets/icons/Menu.svg" alt="" aria-hidden="true" focusable="false">
                 </button>
             </div>
         </div>

--- a/pages/como-funciona.html
+++ b/pages/como-funciona.html
@@ -70,7 +70,8 @@
                     aria-label="Abrir menú"
                 >
                     <img
-                        src = "../assets/icons/Menu.svg"
+                        src="../assets/icons/Menu.svg"
+                        alt=""
                         aria-hidden="true"
                         focusable="false"
                     >

--- a/pages/contacto.html
+++ b/pages/contacto.html
@@ -46,7 +46,7 @@
                 </a>
 
                 <button class="menu-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
-                    <img src="../assets/icons/Menu.svg" aria-hidden="true" focusable="false">
+                    <img src="../assets/icons/Menu.svg" alt="" aria-hidden="true" focusable="false">
                 </button>
             </div>
         </div>

--- a/pages/privacidad.html
+++ b/pages/privacidad.html
@@ -44,7 +44,7 @@
                 </a>
 
                 <button class="menu-toggle" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
-                    <img src="../assets/icons/Menu.svg" aria-hidden="true" focusable="false">
+                    <img src="../assets/icons/Menu.svg" alt="" aria-hidden="true" focusable="false">
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Resumen de cambios:

- `js/header.js`: Añadida la función `setBackgroundHidden()` y llamadas en `openMenu()`/`closeMenu()` para marcar `main`/`footer` con `aria-hidden` cuando el menú móvil está abierto.
- `pages/arroz-con-pollo-scraped.html`: Las pestañas del comparador se convirtieron al patrón ARIA: `role="tablist"`, botones `role="tab"` con `aria-selected`/`aria-controls` y paneles `role="tabpanel"` con `id`/`aria-labelledby` y `tabindex="0"`.
- Se incluye `critical-fixes.patch` con el diff aplicado.

Problemas de accesibilidad corregidos:

- Evita que el contenido de fondo sea accesible por lectores de pantalla mientras el menú móvil está abierto (marque `aria-hidden` en `main`/`footer`).
- Proporciona semántica ARIA a las pestañas del comparador para mejorar la navegación y el anuncio del estado seleccionado por AT.
- Cambios no intrusivos que preservan el comportamiento visual existente.

Pasos básicos de prueba (teclado / lector):

1) Menú móvil
   - Abrir con teclado (Tab → Enter en el botón hamburguesa). Verificar que el foco permanezca dentro del menú; Escape cierra y devuelve foco al botón.
   - Con lector (NVDA/VoiceOver), abrir menú y comprobar que el contenido de fondo no se anuncia ni es navegable.

2) Comparador de ingredientes
   - Abrir comparador, navegar por pestañas con Tab y activar con Enter; cada pestaña debe anunciar "tab" y su estado seleccionado. El panel activo debe tener `role=tabpanel` y `aria-labelledby` apuntando a la pestaña.

3) Badge / Carrito
   - Añadir / eliminar items y verificar que el contador del badge se actualiza correctamente.

Notas:
- No se reescribieron ni se squasharon commits.
- Base: `main`. Head: `fix/accessibility-critical`.
